### PR TITLE
Pins `ncurses` to 5.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,14 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:
     - pkg-config
-    - ncurses
+    - ncurses 5.9*
   run:
-    - ncurses
+    - ncurses 5.9*
 
 test:
   commands:


### PR DESCRIPTION
Pins `ncurses` to 5.9 to match our [pinning wiki](https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies).
